### PR TITLE
Fixed lineWidth setter in b2DebugDraw

### DIFF
--- a/box2d.js
+++ b/box2d.js
@@ -10742,7 +10742,7 @@ Box2D.postDefs = [];
    b2DebugDraw.prototype.SetLineThickness = function (lineThickness) {
       if (lineThickness === undefined) lineThickness = 0;
       this.m_lineThickness = lineThickness;
-      this.m_ctx.strokeWidth = lineThickness;
+      this.m_ctx.lineWidth = lineThickness;
    };
    b2DebugDraw.prototype.GetLineThickness = function () {
       return this.m_lineThickness;


### PR DESCRIPTION
CanvasRenderingContext2D uses lineWidth property, there is no strokeWidth one