### PR TITLE
Semantic Versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "box2dweb",
-  "version": "2.1.0b",
+  "version": "2.1.1",
   "description": "2D physics engine",
   "main": "box2d.js",
   "scripts": {


### PR DESCRIPTION
As of new version of Node/NPM it will automatically update package versions. 
This ended up throwing us to version 2.1.0 since(Apparently npm couldnt understand the -b), back when you had this code:
```
   if(!(Object.prototype.defineProperty instanceof Function)
      && Object.prototype.__defineGetter__ instanceof Function
      && Object.prototype.__defineSetter__ instanceof Function)
    {
       Object.defineProperty = function(obj, p, cfg) {
          if(cfg.get instanceof Function)
             obj.__defineGetter__(p, cfg.get);
          if(cfg.set instanceof Function)
             obj.__defineSetter__(p, cfg.set);
       }
    }
```

which changed the prototype each and every object and if it wasnt for my luck to see the change in package-lock.json it would take days to figure out what went wrong with out code.